### PR TITLE
Palettefix

### DIFF
--- a/SUPer/__init__.py
+++ b/SUPer/__init__.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from .__metadata__ import __name__, __version__
 

--- a/SUPer/__metadata__.py
+++ b/SUPer/__metadata__.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 __MAJOR = 0
 __MINOR = 1

--- a/SUPer/filestreams.py
+++ b/SUPer/filestreams.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import os
 import re

--- a/SUPer/interface.py
+++ b/SUPer/interface.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import gc
 import numpy as np

--- a/SUPer/optim.py
+++ b/SUPer/optim.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import numpy as np
 import numpy.typing as npt

--- a/SUPer/palette.py
+++ b/SUPer/palette.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from dataclasses import dataclass, field
 from collections import namedtuple

--- a/SUPer/pgraphics.py
+++ b/SUPer/pgraphics.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from numpy import typing as npt
 import numpy as np

--- a/SUPer/render2.py
+++ b/SUPer/render2.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
 
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from typing import TypeVar, Optional, Type, Union, Callable
 from dataclasses import dataclass

--- a/SUPer/render2.py
+++ b/SUPer/render2.py
@@ -277,13 +277,14 @@ class GroupingEngine:
         """
         Seek for minimum areas from the regions, sort them and return them sorted,
         ascending area size. The caller will then choose the best area.
-        This function performs an expensive 3D search, only suited for len(srs) <= 16
         """
         windows, areas = {}, {}
         n_regions = len(srs)
 
         if n_regions == 1 or self.n_groups == 1:
             return [(WindowOnBuffer(srs, duration=duration),)]
+        elif n_regions > 16:
+            return None
 
         for key, arrangement in enumerate(__class__._get_combinations(n_regions)):
             arr_sr, other_sr = [], []
@@ -316,9 +317,11 @@ class GroupingEngine:
 
             wobs = self.group_and_sort(tbox, len(subgroup))
             if wobs is None:
-                self.no_blur = False
-                self.blur_mul += 0.5
-                self.blur_c += 0.5
+                if self.no_blur:
+                    self.no_blur = False
+                else:
+                    self.blur_mul += 0.33
+                    self.blur_c += 0.33
         if wobs is None:
             logger.warning("Grouping Engine giving up optimising layout. Using a single window.")
             wobs = [(WindowOnBuffer(tbox, duration=len(subgroup)),)]

--- a/SUPer/segments.py
+++ b/SUPer/segments.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from enum import Enum, IntEnum
 from flags import Flags

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -223,6 +223,11 @@ class TimeConv:
     def f2tc(cls, f: int, fps: float, *, add_one: bool = False) -> str:
         return str(Timecode(round(fps, 2), frames=f+1, force_non_drop_frame=cls.FORCE_NDF))
 
+    @classmethod
+    def add_frames(cls, tc: str, fps: float, nf: int) -> float:
+        fps = round(fps, 2)
+        return cls.tc2s(str(Timecode(fps, tc, force_non_drop_frame=cls.FORCE_NDF) + nf), fps)
+
 def get_matrix(matrix: str, to_rgba: bool, range: str) -> npt.NDArray[np.uint8]:
     """
     Getter of colorspace conversion matrix, BT ITU, limited or full

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from typing import Optional, Callable, TypeVar, Union
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Pillow
 numpy
 py-flags==1.1.4
-sklearn
+scikit-learn
 scikit-image
 guizero
 opencv-python

--- a/supercli.py
+++ b/supercli.py
@@ -89,6 +89,8 @@ if __name__ == '__main__':
 
     if (args.nodts or args.aheadoftime) and ext == 'pes':
         exit_msg("PES output without DTS or with ahead-of-time decoding is not allowed, aborting.")
+    if ext == 'pes' and not args.palette:
+        logger.warning("PES output: generating with full palette flag.")
 
     print("\n @@@@@@@   &@@@  @@@@   @@@@@@@\n"\
           "@@@B &@@@  @@@@  @@@@  @@@@  @@@\n"\

--- a/supergui.py
+++ b/supergui.py
@@ -125,14 +125,18 @@ def set_outputsup() -> None:
     if len(Path(supout.value).name.split('.')) == 1:
         logger.info("No extension given, assuming SUP.")
         supout.value += '.sup'
-    
+
     if supout.value.lower().endswith('pes'):
         set_dts.value = True
         set_dts.enabled = False
         scenarist_checks.value = True
         scenarist_checks.enabled = False
+        scenarist_fullpal.value = True
+        scenarist_fullpal.enabled = False
     else:
         set_dts.enabled = True
+        scenarist_checks.enabled = True
+        scenarist_fullpal.enabled = True
 
     if bdnname.value != '':
         do_super.enabled = True

--- a/supergui.py
+++ b/supergui.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 cibo
-# This file is part of SUPer <https://github.com/cubicibo/SUPer>.
-#
-# SUPer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# SUPer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright (C) 2023 cibo
+This file is part of SUPer <https://github.com/cubicibo/SUPer>.
+
+SUPer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SUPer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 if __name__ == '__main__':
     print("Loading...")

--- a/supergui.py
+++ b/supergui.py
@@ -46,6 +46,7 @@ def get_kwargs() -> dict[str, int]:
         'pgs_compatibility': compat_mode.value,
         'enforce_dts': set_dts.value,
         'no_overlap': scenarist_checks.value,
+        'full_palette': scenarist_fullpal.value,
     }
 
 def wrapper_mp() -> None:
@@ -79,7 +80,6 @@ def wrapper_mp() -> None:
     do_super.queue.put(supname.value)
     do_super.ts = time.time()
 
-
 def monitor_mp() -> None:
     from multiprocessing import Process
     do_reset = False
@@ -107,13 +107,11 @@ def monitor_mp() -> None:
 
 def get_sup() -> None:
     pg_sup_types = ('*.sup', '*.SUP')
-    file_returned = app.select_file(filetypes=[["SUP", pg_sup_types], ["All files", "*"]])
-    supname.value = file_returned
+    supname.value = app.select_file(filetypes=[["SUP", pg_sup_types], ["All files", "*"]])
 
 def get_bdnxml() -> None:
     bdn_xml_types = ("*.xml", "*.XML")
-    file_returned = app.select_file(filetypes=[["BDNXML", bdn_xml_types], ["All files", "*"]])
-    bdnname.value = file_returned
+    bdnname.value = app.select_file(filetypes=[["BDNXML", bdn_xml_types], ["All files", "*"]])
     if supout.value != '':
         do_super.enabled = True
 
@@ -121,14 +119,13 @@ def set_outputsup() -> None:
     pg_sup_types = ('*.sup', '*.SUP')
     pg_pes_types = ('*.pes', '*.PES')
     supout.value = app.select_file(filetypes=[["SUP", pg_sup_types], ['PES', pg_pes_types], ["All files", "*"]], save=True)
-
     if supout.value == '':
         return
 
     if len(Path(supout.value).name.split('.')) == 1:
         logger.info("No extension given, assuming SUP.")
         supout.value += '.sup'
-
+    
     if supout.value.lower().endswith('pes'):
         set_dts.value = True
         set_dts.enabled = False
@@ -244,9 +241,9 @@ if __name__ == '__main__':
 
     scale_fps = CheckBox(app, text="Subsampled BDNXML (e.g. 29.97 BDNXML for 59.94 SUP, ignored if 24p)", grid=[0,pos_v:=pos_v+1,2,1], align='left')
     Hovertip(scale_fps.tk, "A BDNXML generated at half the framerate will limit the pressure on the PG decoder\n"\
-                                   "while ensuring synchronicity with the video footage. This is recommended for 50i/60i content.\n"\
-                                   "E.g if the target is 59.94, the BDNXML would be generated at 29.97. SUPer would then write the PGS\n"\
-                                   "as if it was 59.94. This flag is meaningless with 23.976 or 24p.")
+                           "while ensuring synchronicity with the video footage. This is recommended for 50i/60i content.\n"\
+                           "E.g if the target is 59.94, the BDNXML would be generated at 29.97. SUPer would then write the PGS\n"\
+                           "as if it was 59.94. This flag is meaningless with 23.976 or 24p.")
 
     compat_mode = CheckBox(app, text="Compatibility mode for software players (see tooltip)", grid=[0,pos_v:=pos_v+1,2,1], align='left')
     compat_mode.value = 1
@@ -261,8 +258,14 @@ if __name__ == '__main__':
                          "It must be ticked to ensure compatibility and strict compliancy to Blu-ray specifications.")
 
     scenarist_checks = CheckBox(app, text="Apply additional compliancy rules for Scenarist BD", grid=[0,pos_v:=pos_v+1,2,1], align='left')
+    scenarist_checks.value = 1
     Hovertip(scenarist_checks.tk, "Scenarist BD has additional hard rules. This checkbox enforces them\n"\
                                   "and the generated stream shall pass all Scenarist checks.")
+
+    scenarist_fullpal = CheckBox(app, text="Always write the full palette", grid=[0,pos_v:=pos_v+1,2,1], align='left')
+    Hovertip(scenarist_fullpal.tk, "Scenarist BD mendles with the imported files and may mess up the palette assignments.\n"\
+                                   "Writing the full palette everytime ensures palette data consistency throughout the stream.")
+
 
     bspace = Box(app, layout="grid", grid=[0,pos_v:=pos_v+1,2,1])
     Text(bspace, "Color space: ", grid=[0,0], align='right')

--- a/supergui.py
+++ b/supergui.py
@@ -45,6 +45,7 @@ def get_kwargs() -> dict[str, int]:
         'bt_colorspace': colorspace.value,
         'pgs_compatibility': compat_mode.value,
         'enforce_dts': set_dts.value,
+        'no_overlap': scenarist_checks.value,
     }
 
 def wrapper_mp() -> None:
@@ -131,6 +132,8 @@ def set_outputsup() -> None:
     if supout.value.lower().endswith('pes'):
         set_dts.value = True
         set_dts.enabled = False
+        scenarist_checks.value = True
+        scenarist_checks.enabled = False
     else:
         set_dts.enabled = True
 
@@ -256,6 +259,10 @@ if __name__ == '__main__':
     Hovertip(set_dts.tk, "PG streams include a decoding timestamp. This timestamp is required by old decoders\n"\
                          "else the on-screen behaviour is erratic. This is forcefully ticked for PES+MUI output.\n"\
                          "It must be ticked to ensure compatibility and strict compliancy to Blu-ray specifications.")
+
+    scenarist_checks = CheckBox(app, text="Apply additional compliancy rules for Scenarist BD", grid=[0,pos_v:=pos_v+1,2,1], align='left')
+    Hovertip(scenarist_checks.tk, "Scenarist BD has additional hard rules. This checkbox enforces them\n"\
+                                  "and the generated stream shall pass all Scenarist checks.")
 
     bspace = Box(app, layout="grid", grid=[0,pos_v:=pos_v+1,2,1])
     Text(bspace, "Color space: ", grid=[0,0], align='right')


### PR DESCRIPTION
v0.1.85

- Fix a regression with the grouping engine (essentially a soft lock on very complex epoch layouts)
- Fix a missing palette assignment for screen wipes preceeding acquisitions within an epoch.
- Force the palette to be always written fully in the stream for PES output.