### PR TITLE
Improve RLE encoders and compliancy

### DIFF
--- a/SUPer/optim.py
+++ b/SUPer/optim.py
@@ -67,9 +67,9 @@ class Quantizer:
 
     @classmethod
     def find_options(cls) -> None:
-        cls._opts[cls.Libs.PIL_CV2KM] = ('PIL+KMeans', '(good, fast)')
         if cls._piliq is not None:
             cls._opts[cls.Libs.PILIQ] = (cls.get_piliq().lib_name,'(best, avg)')
+        cls._opts[cls.Libs.PIL_CV2KM] = ('PIL+KMeans', '(good, fast)')
         cls._opts[cls.Libs.CV2KM]     = ('KMeans', '(best, slow)')
         #cls._opts[cls.Libs.PILLOW]    = ('PIL', '(average, fast)')
 


### PR DESCRIPTION
BD specs claims that the length of all run-length encoded lines must be smaller than the width of the image + 16 (some "coding overhead").

The RLE method described in US7912305B1 may only produce RLE lines longer than the bitmap width when color 0x00 alternates with another every other pixel. If the situtation arises with a color other than 0x00, the encoded line length will equal the width, at worst.

This MR prevents the usage of color 0x00 in the bitmap, but not for padding.
Additionally, the RLE encoders and decoders have been rewritten from scratch to improve the logic and efficiency.