### PR TITLE
Define buffer slot dimensions to largest graphic for each windows

### DIFF
--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -148,6 +148,12 @@ class Box:
     @classmethod
     def from_coords(cls, x1: int, y1: int, x2 : int, y2: int) -> 'Box':
         return cls(min(y1, y2), abs(y2-y1), min(x1, x2), abs(x2-x1))
+
+    def __eq__(self, other: 'Box') -> bool:
+        if isinstance(other, __class__):
+            return self.coords == other.coords
+        return NotImplemented
+
 ####
 
 #%%


### PR DESCRIPTION
- During an epoch, analyze the shape of all graphics displayed in a window and take the maximum width and height to define the buffer slot.
- Perform acquisitions whenever new graphics is displayed outside of the slot.

This MR has pro and cons:
- Con: Graphics that display and undisplay synchronously within a very large windows will require an acquisition while before these could be done via a palette update.
- Pros: The smaller object area reduces decoding time, fewer events may be dropped in situations with large windows or high framerates. Also, this enables moves in larger areas of the screen without dropouts.