### PR TITLE
Attempt to define object early if acquisition is impossible

### DIFF
--- a/SUPer/pgraphics.py
+++ b/SUPer/pgraphics.py
@@ -458,6 +458,12 @@ class PGObject:
             return self.mask[frame-self.f]
         return False
 
+    def pad_left(self, padding: int) -> None:
+        assert padding > 0
+        self.f -= padding
+        self.mask[0:0] = [False] * padding
+        self.gfx = np.concatenate((np.zeros((padding, *self.gfx.shape[1:]), np.uint8), self.gfx), axis=0, dtype=np.uint8)
+
     @staticmethod
     def _bbox(img: npt.NDArray[np.uint8]) -> Box:
         rmin, rmax = np.where(np.any(img, axis=1))[0][[0, -1]]


### PR DESCRIPTION
This MR attempts to shift forward object decoding and drawing if an acquisition cannot be performed when this object is first used. If the associated window is empty, the object is decoded and drawn (transparently) early to the plane. It is then displayed in due time with a palette update.