### PR TITLE
Remove duplicate FPS field, fix frame_duration check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The config.ini file can be used to specify the relative or absolute path to a qu
  -p, --palette       Flag to always write the full palette (enforced for PES).
  -y, --yes           Flag to overwrite output file if it already exists.
  -w, --withsup       Flag to write both SUP and PES+MUI files.
- -t, --tslong        Flag to use a conservative PTS/DTS strategy (more events may be filtered out on complex animations).
  -m, --max-kbps      Set the maximum bitrate to test the output against. Recommended range: [500-16000].
  -e, --extra-acq     Set the min count of palette update after which acquisitions should be inserted [0: off, default: 2]
  -l, --log-to-file   Set (enable) logging to file and set logging level: [10: debug, 20: info, 25: iinf, 30: warnings]
@@ -53,11 +52,7 @@ The config.ini file can be used to specify the relative or absolute path to a qu
 - The output file extension is used to infer the desired output type (SUP or PES).
 - If `--allow-normal`  is used in a Scenarist BD project, one must not "Encode->Build" or "Encode->Rebuild" the PES assets. Scenarist BD does not implement normal case object redefinition and may destroy the stream. However, building or rebuilding are not mendatory to mux the project.
 - `--max-kbps` does not shape the stream, it is just a limit to compare it to. Only `--compression` and `--qmode` may be used to reduce the filesize.
-
-Additionally, one flag is available to generate SUPs that are not subject to decoding constraints. This flag is unmaintained code and its operability not guaranteed.
-```
- --nodts         Flag to not set the DTS in stream (NOT compliant).
-```
+- SUPer shall only generate strictly compliant datastream. No option or value will break compliancy.
 
 ## Misc
 ### GUI/CLI options
@@ -67,14 +62,13 @@ Here are some additional informations on selected options, especially those that
 - Quantization: image quantizer to use. PIL+K-Means is low quality but fast. K-Means and pngquant/libimagequant are high quality but slower.
 - Allow normal case object redefinition: whenever possible, update a single object out of two. The requirements are complex so this option may have no effect for some files. Also, the palette is split 50/50 in the vicinity of these events in the stream.
 - Subsampled BDN XML: Generate a 50/59.94 fps SUP for a 25/29.97 fps BDN input.
-- Conservative PTS/DTS strategy: doubles the graphic plane access time whenever a drawing operation is performed.
 - Insert acquisition: Palette effects are encoded in a single bitmap and the output of the last palette update may remain on screen for sufficiently long. Artifacts may come to the viewer attention if they remain visible long enough on the screen. Refreshing the screen will hide potential side effects and improve the perceived quality. You may lower the value if you feel like the filesize increases too significantly, or disable this behavior altogether.
 
 ### TL;DR Options
 First of all, one should leave the acquisition rate untouched at 100%, unless the stream is highly compressible (i.e includes solely a karaoke).
 
-- No faith in SUPer: Use a low compression rate (< 50%), use the conservative PTS/DTS strategy. Import the resulting PES+MUI in Scenarist BD and use the Encode->Rebuild functionality. Scenarist BD will re-write the SUP according to their logic without compromising integrity.
-- Have faith in SUPer: Do not use the conservative PTS/DTS strategy, set to allow normal case object redefinition, and use an appropriate compression rate (50-85% typ.). Then, in Scenarist BD, mux your project without ever attempting to Encode->Build/Rebuild the PES project.
+- No faith in SUPer: Use a low compression rate (< 50%). Import the resulting PES+MUI in Scenarist BD and use the Encode->Rebuild functionality. Scenarist BD will re-write the SUP according to their logic without compromising integrity.
+- Have faith in SUPer: Set to allow normal case object redefinition, and use an appropriate compression rate (50-85% typ.). Then, in Scenarist BD, mux your project without ever attempting to Encode->Build/Rebuild the PES+MUI files.
 
 ### How SUPer works
 SUPer implements a conversion engine that uses the entirety of the PG specs described in the two patents US8638861B2 and US20090185789A1. PG decoders, while designed to be as cheap as possible, feature a few nifty capabilities that includes palette updates, object redefinition, object cropping and events buffering.

--- a/SUPer/filestreams.py
+++ b/SUPer/filestreams.py
@@ -524,7 +524,7 @@ class BDNXML(SeqIO):
 
         hformat = header.find('Format')
         self.fps = float(hformat.attrib['FrameRate'])
-        self.dropframe = bool(1 if hformat.attrib['DropFrame'].lower() == 'true' else 0)
+        self.dropframe = bool(hformat.attrib['DropFrame'].lower() == 'true')
         self.format = hformat.attrib['VideoFormat']
 
     def _parse_events(self) -> None:

--- a/SUPer/interface.py
+++ b/SUPer/interface.py
@@ -164,17 +164,17 @@ class BDNRender:
         # Final check
         logger.info("Checking stream consistency and compliancy...")
         final_fps = round(bdn.fps, 2) * int(1+scaled_fps)
-        compliant, warnings = is_compliant(self._epochs, final_fps, self.kwargs.get('enforce_dts', True), self.kwargs.get('adjust_ntsc', False))
+        compliant, warnings = is_compliant(self._epochs, final_fps)
 
-        if compliant and self.kwargs.get('enforce_dts', True):
+        if compliant:
             logger.info("Checking PTS and DTS rules...")
-            compliant &= check_pts_dts_sanity(self._epochs, final_fps, self.kwargs.get('adjust_ntsc', False))
+            compliant &= check_pts_dts_sanity(self._epochs, final_fps)
             if not compliant:
                 logger.error("=> Stream has a PTS/DTS issue!!")
             elif (max_bitrate := self.kwargs.get('max_kbps', False)) > 0:
                 logger.info(f"Checking PG buffer usage w.r.t bitrate: {max_bitrate} Kbps")
                 max_bitrate = max_bitrate*1000/8
-                warnings += not test_rx_bitrate(self._epochs, int(max_bitrate), final_fps, self.kwargs.get('adjust_ntsc', False))
+                warnings += not test_rx_bitrate(self._epochs, int(max_bitrate), final_fps)
         if warnings == 0 and compliant:
             logger.info("=> Output PGS seems compliant.")
         if warnings > 0 and compliant:

--- a/SUPer/interface.py
+++ b/SUPer/interface.py
@@ -76,15 +76,13 @@ class BDNRender:
                 import sys
                 sys.exit(1)
 
-        clip_framerate = bdn.fps
         if isinstance(bdn.fps, float) and not bdn.dropframe:
-            bdn.fps = round(bdn.fps)
-            self.kwargs['adjust_dropframe'] = True
+            self.kwargs['adjust_ntsc'] = True
             logger.info(f"NDF NTSC detected: scaling all timestamps by 1.001.")
         else:
-            self.kwargs['adjust_dropframe'] = False
+            self.kwargs['adjust_ntsc'] = False
 
-        self._first_pts = max(TC.tc2s(bdn.events[0].tc_in, bdn.fps) - (1/3)/PGDecoder.FREQ, 0) * (1.001 if self.kwargs['adjust_dropframe'] else 1.0)
+        self._first_pts = max(TC.tc2s(bdn.events[0].tc_in, bdn.fps) - (1/3)/PGDecoder.FREQ, 0) * (1.001 if self.kwargs['adjust_ntsc'] else 1.0)
 
         logger.info("Finding epochs...")
 
@@ -149,7 +147,7 @@ class BDNRender:
                 else:
                     logger.info(f" => Screen layout: {len(wob)} window(s), processing...")
 
-                wobz = WOBSAnalyzer(wob, subgroup, box, clip_framerate, bdn, pcs_id=pcs_id, **kwargs)
+                wobz = WOBSAnalyzer(wob, subgroup, box, bdn, pcs_id=pcs_id, **kwargs)
                 new_epoch, final_ds, pcs_id = wobz.analyze()
                 self._epochs.append(new_epoch)
                 logger.info(f" => optimised as {len(self._epochs[-1])} display sets.")
@@ -165,18 +163,18 @@ class BDNRender:
 
         # Final check
         logger.info("Checking stream consistency and compliancy...")
-        final_fps = bdn.fps * int(1+scaled_fps)
-        compliant, warnings = is_compliant(self._epochs, final_fps, self.kwargs.get('enforce_dts', True), self.kwargs.get('adjust_dropframe', False))
+        final_fps = round(bdn.fps, 2) * int(1+scaled_fps)
+        compliant, warnings = is_compliant(self._epochs, final_fps, self.kwargs.get('enforce_dts', True), self.kwargs.get('adjust_ntsc', False))
 
         if compliant and self.kwargs.get('enforce_dts', True):
             logger.info("Checking PTS and DTS rules...")
-            compliant &= check_pts_dts_sanity(self._epochs, final_fps, self.kwargs.get('adjust_dropframe', False))
+            compliant &= check_pts_dts_sanity(self._epochs, final_fps, self.kwargs.get('adjust_ntsc', False))
             if not compliant:
                 logger.error("=> Stream has a PTS/DTS issue!!")
             elif (max_bitrate := self.kwargs.get('max_kbps', False)) > 0:
                 logger.info(f"Checking PG buffer usage w.r.t bitrate: {max_bitrate} Kbps")
                 max_bitrate = max_bitrate*1000/8
-                warnings += not test_rx_bitrate(self._epochs, int(max_bitrate), final_fps, self.kwargs.get('adjust_dropframe', False))
+                warnings += not test_rx_bitrate(self._epochs, int(max_bitrate), final_fps, self.kwargs.get('adjust_ntsc', False))
         if warnings == 0 and compliant:
             logger.info("=> Output PGS seems compliant.")
         if warnings > 0 and compliant:

--- a/SUPer/interface.py
+++ b/SUPer/interface.py
@@ -76,13 +76,11 @@ class BDNRender:
                 import sys
                 sys.exit(1)
 
-        if isinstance(bdn.fps, float) and not bdn.dropframe:
-            self.kwargs['adjust_ntsc'] = True
+        self.kwargs['adjust_ntsc'] = isinstance(bdn.fps, float) and not bdn.dropframe
+        if self.kwargs['adjust_ntsc']:
             logger.info(f"NDF NTSC detected: scaling all timestamps by 1.001.")
-        else:
-            self.kwargs['adjust_ntsc'] = False
 
-        self._first_pts = max(TC.tc2s(bdn.events[0].tc_in, bdn.fps) - (1/3)/PGDecoder.FREQ, 0) * (1.001 if self.kwargs['adjust_ntsc'] else 1.0)
+        self._first_pts = TC.tc2pts(bdn.events[0].tc_in, bdn.fps)
 
         logger.info("Finding epochs...")
 

--- a/SUPer/optim.py
+++ b/SUPer/optim.py
@@ -319,9 +319,9 @@ class Optimise:
         :return: N palette objects defining palette that can be converted to PDSes.
         """
         stacked_cluts =  np.swapaxes(cluts, 1, 0)
+
         if to_ycbcr:
-            PE_fn = lambda rgba: PaletteEntry.from_rgba(rgba, matrix=matrix,
-                                                        s_range=s_range)
+            PE_fn = lambda rgba: PaletteEntry.from_rgba(rgba, matrix=matrix, s_range=s_range)
         else:
             PE_fn = lambda ycbcra: PaletteEntry(*ycbcra)
 

--- a/SUPer/pgraphics.py
+++ b/SUPer/pgraphics.py
@@ -26,7 +26,7 @@ from itertools import starmap
 
 from .palette import Palette, PaletteEntry
 from .segments import WDS, ODS, DisplaySet, PDS
-from .utils import Shape, Box
+from .utils import Shape, Box, MPEGTS_FREQ
 
 from dataclasses import dataclass
 #%%
@@ -339,7 +339,7 @@ class PGDecoder:
     RX =  2e6
     RD = 16e6
     RC = 32e6
-    FREQ = 90e3
+    FREQ = MPEGTS_FREQ
     DECODED_BUF_SIZE = 4*(1024**2)
     CODED_BUF_SIZE   = 1*(1024**2)
 

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -34,6 +34,8 @@ try:
 except ModuleNotFoundError:
     from contextlib import nullcontext as tqdm
 
+MPEGTS_FREQ = int(90e3)
+
 RegionType = TypeVar('Region')
 _BaseEvent = TypeVar('BaseEvent')
 
@@ -393,6 +395,10 @@ class TimeConv:
     def add_frames(cls, tc: str, fps: float, nf: int) -> float:
         fps = round(fps, 2)
         return cls.tc2s(cls.add_framestc(tc, fps, nf), fps)
+    
+    @classmethod
+    def tc2pts(cls, tc: str, fps: float) -> float:
+        return max(0, (cls.tc2s(tc, fps) - (1/3)/MPEGTS_FREQ)) * (1 if float(fps).is_integer() else 1.001)
 
 def get_matrix(matrix: str, to_rgba: bool, range: str) -> npt.NDArray[np.uint8]:
     """

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -227,10 +227,9 @@ class WindowOnBuffer:
 #%%
 class BDVideo:
     class FPS(Enum):
-        NTSCi_NDF = 60 #Illegal, just for NDF timing
+        HFR_60 = 60
         NTSCi = 59.94
         PALi  = 50
-        NTSCp_NDF = 30 #Illegal, just for NDF timing
         NTSCp = 29.97
         PALp  = 25
         FILM  = 24
@@ -295,6 +294,13 @@ class BDVideo:
         SD576_43  = (720,  576)
         SD480_43  = (720,  480)
 
+        @classmethod
+        def from_height(cls, height: int) -> 'BDVideo.VideoFormat':
+            for fmt in cls:
+                if fmt[1] == height:
+                    return cls(*fmt)
+            raise ValueError(f"Unknown video format with height '{height}'.")
+
     class PCSFPS(IntEnum):
         FILM_NTSC_P = 0x10
         FILM_24P    = 0x20
@@ -302,7 +308,7 @@ class BDVideo:
         NTSC_P      = 0x40
         PAL_I       = 0x60
         NTSC_I      = 0x70
-        FPS_60      = 0x80
+        HFR_60      = 0x80
 
         @classmethod
         def from_fps(cls, other: float):
@@ -313,22 +319,11 @@ class BDVideo:
         24:    0x20,
         25:    0x30,
         29.97: 0x40,
-        30:    0x40,#hack for NDF timing
         50:    0x60,
         59.94: 0x70,
-        60:    0x70 #hack for NDF timing
+        60:    0x80,
     }
-
-    LUT_FPS_PCSFPS = {
-        0x10: 23.976,
-        0x20: 24,
-        0x30: 25,
-        0x40: 30, #hack for NDF timing
-        0x40: 29.97,
-        0x60: 50,
-        0x70: 60, #hack for NDF timing
-        0x70: 59.94,
-    }
+    LUT_FPS_PCSFPS = {v: k for k,v in LUT_PCS_FPS.items()}
 
     def __init__(self, fps: float, height: int, width: Optional[int] = None) -> None:
         self.fps = __class__.FPS(fps)
@@ -341,7 +336,7 @@ class BDVideo:
                     break
             assert self.format is not None
         else:
-            self.format = __class__.VideoFormat((height, width))
+            self.format = __class__.VideoFormat((width, height))
 
 
 class TimeConv:

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -389,7 +389,10 @@ class TimeConv:
     @classmethod
     def add_framestc(cls, tc: str, fps: float, nf: int) -> str:
         fps = round(fps, 2)
-        return str(Timecode(fps, tc, force_non_drop_frame=cls.FORCE_NDF) + nf)
+        tc_udf = Timecode(fps, tc, force_non_drop_frame=cls.FORCE_NDF) + nf
+        if cls.FORCE_NDF:
+            tc_udf.drop_frame = False
+        return str(tc_udf)
 
     @classmethod
     def add_frames(cls, tc: str, fps: float, nf: int) -> float:

--- a/supercli.py
+++ b/supercli.py
@@ -74,14 +74,12 @@ if __name__ == '__main__':
     parser.add_argument('-l', '--log-to-file', help="Enable logging to file and specify the minimum logging level. [10: debug, 20: normal, 30: warn/errors]", type=int, default=-1, required=False)
     parser.add_argument('--ssim-tol', help="Set a SSIM analysis offset (positive: higher sensitivity) [int, -100-100] (def:  %(default)s)", type=int, default=0, required=False)
 
-    #parser.add_argument('--nodts', help="Flag to not set DTS in stream (NOT COMPLIANT)", action='store_true', default=False, required=False)
     #parser.add_argument('--aheadoftime', help="Flag to allow ahead of time decoding. (NOT COMPLIANT)", action='store_true', default=False, required=False)
 
     parser.add_argument('-v', '--version', action='version', version=f"(c) {__author__}, v{LIB_VERSION}")
     parser.add_argument("output", type=str)
     args = parser.parse_args()
     args.aheadoftime = False
-    args.nodts = False
 
     #### Sanity checks and conversion
     args.output, ext = check_output(args.output, args.yes)
@@ -165,7 +163,6 @@ if __name__ == '__main__':
         'scale_fps': args.subsampled,
         'quantize_lib': args.qmode,
         'bt_colorspace': f"bt{args.bt}",
-        'enforce_dts': not args.nodts,
         'no_overlap': not args.aheadoftime,
         'full_palette': args.palette,
         'output_all_formats': args.withsup,

--- a/supercli.py
+++ b/supercli.py
@@ -69,19 +69,19 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--palette', help="Flag to always write the full palette.", action='store_true', default=False, required=False)
     parser.add_argument('-y', '--yes', help="Flag to overwrite output file", action='store_true', default=False, required=False)
     parser.add_argument('-w', '--withsup', help="Flag to write both SUP and PES+MUI files.", action='store_true', default=False, required=False)
-    parser.add_argument('-t', '--tslong', help="Flag to use PTS/DTS strategy with additional margins.", action='store_true', default=False, required=False)
     parser.add_argument('-e', '--extra-acq', help="Set min count of palette updates needed to add an acquisition. [0: off] (def:  %(default)s)", type=int, default=2, required=False)
     parser.add_argument('-m', '--max-kbps', help="Set a max bitrate to validate the output against.", type=int, default=0, required=False)
     parser.add_argument('-l', '--log-to-file', help="Enable logging to file and specify the minimum logging level. [10: debug, 20: normal, 30: warn/errors]", type=int, default=-1, required=False)
     parser.add_argument('--ssim-tol', help="Set a SSIM analysis offset (positive: higher sensitivity) [int, -100-100] (def:  %(default)s)", type=int, default=0, required=False)
 
-    parser.add_argument('--nodts', help="Flag to not set DTS in stream (NOT COMPLIANT)", action='store_true', default=False, required=False)
+    #parser.add_argument('--nodts', help="Flag to not set DTS in stream (NOT COMPLIANT)", action='store_true', default=False, required=False)
     #parser.add_argument('--aheadoftime', help="Flag to allow ahead of time decoding. (NOT COMPLIANT)", action='store_true', default=False, required=False)
 
     parser.add_argument('-v', '--version', action='version', version=f"(c) {__author__}, v{LIB_VERSION}")
     parser.add_argument("output", type=str)
     args = parser.parse_args()
     args.aheadoftime = False
+    args.nodts = False
 
     #### Sanity checks and conversion
     args.output, ext = check_output(args.output, args.yes)
@@ -100,10 +100,10 @@ if __name__ == '__main__':
         logger.warning("Got invalid extra-acq, disabling option.")
         args.extra_acq = 0
 
-    if args.max_kbps > 40000:
-        logger.warning("Max bitrate is beyond total BDAV video limits.")
+    if args.max_kbps > 48000:
+        logger.warning("Max bitrate is beyond total BDAV limit.")
     elif 10 < args.max_kbps < 500:
-        logger.warning("Max bitrate is low. Buffer underflow errors may be spammed.")
+        logger.warning("Max bitrate is low. Buffer underflow errors will be spammed.")
     elif args.max_kbps < 10 and args.max_kbps != 0:
         exit_msg("Meaningless max bitrate, aborting.")
 
@@ -170,7 +170,6 @@ if __name__ == '__main__':
         'full_palette': args.palette,
         'output_all_formats': args.withsup,
         'normal_case_ok': args.allow_normal,
-        'ts_long': args.tslong,
         'max_kbps': args.max_kbps,
         'log_to_file': args.log_to_file,
         'insert_acquisitions': args.extra_acq,

--- a/supergui.py
+++ b/supergui.py
@@ -38,7 +38,7 @@ from SUPer.__metadata__ import __version__ as SUPVERS, __author__
 ### CONSTS
 SUPER_STRING = "Make it SUPer!"
 
-#### FUnctions, main at the end of the file
+#### Functions, main at the end of the file
 def get_kwargs() -> dict[str, int]:
     return {
         'quality_factor': int(compression_txt.value)/100,
@@ -53,7 +53,6 @@ def get_kwargs() -> dict[str, int]:
         'normal_case_ok': bool(normal_case_ok.value),
         'insert_acquisitions': int(biacqs_val.value),
         'libs_path': lib_paths,
-        'ts_long': bool(soft_dts.value),
         'max_kbps': int(max_kbps.value),
         'log_to_file': opts_log[logcombo.value],
         'ssim_tol': int(ssim_tolb.value)/100,
@@ -73,7 +72,7 @@ def wrapper_mp() -> None:
         invalid |= not (0 <= kwargs['insert_acquisitions'])
         invalid |= not (0 <= kwargs['quality_factor'] <= 1)
         invalid |= not (0 <= kwargs['refresh_rate'] <= 1)
-        invalid |= kwargs['max_kbps'] <= 0
+        invalid |= kwargs['max_kbps'] <= 0 or kwargs['max_kbps'] >= 48000
         if invalid:
             logger.error("Invalid parameter found, aborting.")
             return
@@ -127,7 +126,7 @@ def hide_chkbox() -> None:
         set_dts.enabled = scenarist_fullpal.enabled = False
         #scenarist_checks.enabled = False
     elif not supout.value.lower().endswith('pes'):
-        set_dts.enabled = True
+        #set_dts.enabled = True
         scenarist_fullpal.enabled = True
         #scenarist_checks.enabled = True
 
@@ -157,7 +156,7 @@ def set_outputsup() -> None:
         scenarist_fullpal.enabled = False
     else:
         if not all_formats.value:
-            set_dts.enabled = True
+            #set_dts.enabled = True
             #scenarist_checks.enabled = True
             scenarist_fullpal.enabled = True
 
@@ -297,9 +296,10 @@ if __name__ == '__main__':
 
     set_dts = CheckBox(app, text="Enforce strict compliancy (see tooltip)", grid=[0,pos_v:=pos_v+1,2,1], align='left')
     set_dts.value = True
-    Hovertip(set_dts.tk, "PG streams include a decoding timestamp. This timestamp is required by old decoders\n"\
-                         "else the on-screen behaviour is erratic. This is forcefully ticked for PES+MUI output.\n"\
-                         "It must be ticked to ensure compatibility and strict compliancy to Blu-ray specifications.")
+    set_dts.enabled = False
+    Hovertip(set_dts.tk, "If ticked, set the decoding timestamp in the stream to ensure strict compliancy and compatibility.\n"\
+                        f"\nNOTE: This is forcefully ticked, the generation of out-of-spec streams is now forbidden.\n"\
+                         "This checkbox will be dropped in the future.")
 
     #scenarist_checks = CheckBox(app, text="Apply additional compliancy rules for Scenarist BD", grid=[0,pos_v:=pos_v+1,2,1], align='left')
     #scenarist_checks.value = 1
@@ -317,10 +317,6 @@ if __name__ == '__main__':
                            "while ensuring synchronicity with the video footage. This is recommended for 50i/60i content.\n"\
                            "E.g if the target is 59.94, the BDNXML would be generated at 29.97. SUPer would then write the PGS\n"\
                            "as if it was 59.94. This flag is meaningless with 23.976 or 24p.")
-
-    soft_dts = CheckBox(app, text="Use PTS/DTS strategy with margin.", grid=[0,pos_v:=pos_v+1,2,1], align='left')
-    Hovertip(soft_dts.tk, "When new objects are defined, the DTS-PTS delta includes an additional (unecessary) margin.\n"\
-                          "This reduces the ability to perform acquisitions.")
 
     biacqs = Box(app, layout="grid", grid=[0, pos_v:=pos_v+1, 2, 1], align='left')
     biacqs_val = TextBox(biacqs, width=2, height=1, grid=[0,0], text="2")

--- a/supergui.py
+++ b/supergui.py
@@ -46,7 +46,6 @@ def get_kwargs() -> dict[str, int]:
         'scale_fps': bool(scale_fps.value),
         'quantize_lib': Quantizer.get_option_id(quantcombo.value),
         'bt_colorspace': colorspace.value,
-        'enforce_dts': bool(set_dts.value),
         'no_overlap': True, #scenarist_checks.value,
         'full_palette': bool(scenarist_fullpal.value),
         'output_all_formats': bool(all_formats.value),
@@ -120,13 +119,11 @@ def monitor_mp() -> None:
 
 def hide_chkbox() -> None:
     if all_formats.value:
-        set_dts.value = True
         scenarist_fullpal.value = True
         #scenarist_checks.value = True
-        set_dts.enabled = scenarist_fullpal.enabled = False
+        scenarist_fullpal.enabled = False
         #scenarist_checks.enabled = False
     elif not supout.value.lower().endswith('pes'):
-        #set_dts.enabled = True
         scenarist_fullpal.enabled = True
         #scenarist_checks.enabled = True
 
@@ -148,15 +145,12 @@ def set_outputsup() -> None:
         supout.value += '.sup'
 
     if supout.value.lower().endswith('pes'):
-        set_dts.value = True
-        set_dts.enabled = False
         #scenarist_checks.value = True
         #scenarist_checks.enabled = False
         scenarist_fullpal.value = True
         scenarist_fullpal.enabled = False
     else:
         if not all_formats.value:
-            #set_dts.enabled = True
             #scenarist_checks.enabled = True
             scenarist_fullpal.enabled = True
 
@@ -293,13 +287,6 @@ if __name__ == '__main__':
     Hovertip(normal_case_ok.tk, "This option may reduce the number of dropped events on complicated animations.\n"\
                                 "When there are two objects on screen and one must be updated, it may be possible\n"\
                                 "to update the given object in a tighter time window than in an acquisition (both objects refreshed).")
-
-    set_dts = CheckBox(app, text="Enforce strict compliancy (see tooltip)", grid=[0,pos_v:=pos_v+1,2,1], align='left')
-    set_dts.value = True
-    set_dts.enabled = False
-    Hovertip(set_dts.tk, "If ticked, set the decoding timestamp in the stream to ensure strict compliancy and compatibility.\n"\
-                        f"\nNOTE: This is forcefully ticked, the generation of out-of-spec streams is now forbidden.\n"\
-                         "This checkbox will be dropped in the future.")
 
     #scenarist_checks = CheckBox(app, text="Apply additional compliancy rules for Scenarist BD", grid=[0,pos_v:=pos_v+1,2,1], align='left')
     #scenarist_checks.value = 1


### PR DESCRIPTION
- WOBAnalyzer had twice the FPS value, once rounded, and once not. Remove the unecessary rounding.
- Fix some bad naming.
- Fix a hidden bug in TimeConv class: add_framestc would return a DF TC with NTSC framerates with the removed rounding.