### PR TITLE
Add multithreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ The config.ini file can be used to specify the relative or absolute path to a qu
  -a, --acqrate       Set the acquisition rate, lower values will compress the stream but lower quality. [int, 0-100, def: 100]
  -q, --qmode         Set the image quantization mode. [1: PIL+K-Means on fades, 2: K-Means, 3: PILIQ, def: 1]
  -n, --allow-normal  Flag to allow normal case object redefinition, can reduce the number of dropped events on complex animations.
+ -t, --threads       Set the number of concurrent threads to use. Default is 1, maximum is 8.
  -b, --bt            Set the target BT matrix [601, 709, 2020, def: 709]
- -s, --subsampled    Flag to indicate BDNXML is subsampled (e.g 29.97 BDNXML for 59.94 output).
  -p, --palette       Flag to always write the full palette (enforced for PES).
  -y, --yes           Flag to overwrite output file if it already exists.
  -w, --withsup       Flag to write both SUP and PES+MUI files.
  -m, --max-kbps      Set the maximum bitrate to test the output against. Recommended range: [500-16000].
  -e, --extra-acq     Set the min count of palette update after which acquisitions should be inserted [0: off, default: 2]
+ -s, --subsampled    Flag to indicate BDNXML is subsampled (e.g 29.97 BDNXML for 59.94 output).
  -l, --log-to-file   Set (enable) logging to file and set logging level: [10: debug, 20: info, 25: iinf, 30: warnings]
  -v, --version       Print the version and exit.
  --ssim-tol          Adjust the SSIM tolerance threshold. This threshold is used for bitmaps classification in effects [-100; 100, def: 0] 

--- a/SUPer/filestreams.py
+++ b/SUPer/filestreams.py
@@ -19,7 +19,6 @@ along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
-import re
 import xml.etree.ElementTree as ET
 import numpy as np
 
@@ -39,7 +38,7 @@ except ModuleNotFoundError:
     _has_numba = False
 
 from .segments import PGSegment, PCS, DisplaySet, Epoch
-from .utils import (BDVideo, TimeConv as TC, LogFacility, Shape, Pos, Dim, Box)
+from .utils import (BDVideo, TimeConv as TC, LogFacility, Shape, Box)
 
 logger = LogFacility.get_logger('SUPer')
 
@@ -262,7 +261,7 @@ class BaseEvent:
     @property
     def tc_out(self) -> str:
         return self._outtc
-    
+
     @tc_out.setter
     def tc_out(self, tc_out: str) -> None:
         self._outtc = tc_out
@@ -336,7 +335,7 @@ class BDNXMLEvent(BaseEvent):
         assert self._img.height == self._height
 ####BDNXMLEvent
 
-if _has_numba:    
+if _has_numba:
     @njit(fastmath=True)
     def _compare_images(images: list[npt.NDArray[np.uint8]]) -> list[np.bool_]:
         diff_list = [np.bool_(1) for x in range(len(images)-1)]
@@ -364,7 +363,7 @@ def remove_dupes(events: list[BDNXMLEvent]) -> list[BDNXMLEvent]:
         flags = _compare_images(imgs)
     else:
         flags = _compare_images([event.img for event in events])
-        
+
     output_events = [events[0]]
     for event, flag in zip(events[1:], flags):
         if flag or output_events[-1].tc_out != event.tc_in:

--- a/SUPer/interface.py
+++ b/SUPer/interface.py
@@ -24,12 +24,13 @@ from os import path
 
 from scenaristream import EsMuiStream
 
-from .utils import TimeConv as TC, LogFacility, Box, BDVideo
+from .utils import TimeConv as TC, LogFacility, Box, BDVideo, SSIMPW
 from .pgraphics import PGDecoder
 from .filestreams import BDNXML, remove_dupes
 from .optim import Quantizer
 from .pgstream import is_compliant, check_pts_dts_sanity, test_rx_bitrate
 
+#%%
 logger = LogFacility.get_logger('SUPer')
 
 class BDNRender:
@@ -50,6 +51,10 @@ class BDNRender:
                     if not Quantizer.init_piliq(*piq_params):
                         logger.info("Failed to initialise advanced image quantizer. Falling back to PIL+K-Means.")
                         self.kwargs['quantize_lib'] = Quantizer.Libs.PIL_CV2KM.value
+
+        if (sup_params := self.kwargs.pop('super_cfg', None)) is not None:
+            SSIMPW.use_gpu = bool(int(sup_params.get('use_gpu', True)))
+            logger.debug(f"OpenCL enabled: {SSIMPW.use_gpu}.")
 
         file_logging_level = self.kwargs.get('log_to_file', False)
         if file_logging_level > 0:

--- a/SUPer/optim.py
+++ b/SUPer/optim.py
@@ -22,7 +22,6 @@ import numpy as np
 import numpy.typing as npt
 
 from PIL import Image, ImagePalette
-from SSIM_PIL import compare_ssim
 
 from typing import Optional, Union
 from collections.abc import Iterable
@@ -31,7 +30,7 @@ from piliq import PILIQ
 import cv2
 
 from .palette import Palette, PaletteEntry
-from .utils import TimeConv as TC, LogFacility, get_matrix
+from .utils import TimeConv as TC, LogFacility, get_matrix, SSIMPW
 
 logger = LogFacility.get_logger('SUPer')
 
@@ -145,7 +144,7 @@ class Preprocess:
             pil_failed = len(img_out.palette.colors) != 1+max(img_out.palette.colors.values())
 
             #When PIl fails to quantize alpha channel, there's a clear discrepancy between original and quantized image.
-            pil_failed = pil_failed or compare_ssim(Image.fromarray(nppal[npimg], 'RGBA'), img) < 0.95
+            pil_failed = pil_failed or SSIMPW.compare(Image.fromarray(nppal[npimg], 'RGBA'), img) < 0.95
 
             if pil_failed:
                 logger.ldebug("Pillow failed to palettize image, falling back to K-Means.")

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -382,6 +382,7 @@ def get_matrix(matrix: str, to_rgba: bool, range: str) -> npt.NDArray[np.uint8]:
 class LogFacility:
     _logger = dict()
     _logpbar = dict()
+    _tqdm_off = False
 
     @classmethod
     def set_file_log(cls, logger: logging.Logger, fp: str, level: Optional[int] = None) -> None:
@@ -449,6 +450,10 @@ class LogFacility:
         logging.Logger.hdebug = high_debug
 
     @classmethod
+    def disable_tqdm(cls) -> None:
+        cls._tqdm_off = True
+
+    @classmethod
     def close_progress_bar(cls, logger: logging.Logger):
         if cls._logger.get(logger.name, None) != None and cls._logpbar.get(logger.name, None) is not None:
             cls._logpbar[logger.name].close()
@@ -460,7 +465,7 @@ class LogFacility:
             return None
         if cls._logpbar.get(logger.name, None) is not None:
             return cls._logpbar[logger.name]
-        if logger.getEffectiveLevel() >= logging.INFO:
+        if logger.getEffectiveLevel() >= logging.INFO and not cls._tqdm_off:
             pbar = tqdm(tot)
         else:
             pbar = nullcontext()

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -29,6 +29,8 @@ from timecode import Timecode
 from dataclasses import dataclass
 from contextlib import nullcontext
 from functools import lru_cache
+from PIL import Image
+from SSIM_PIL import compare_ssim
 
 try:
     from tqdm import tqdm
@@ -318,10 +320,17 @@ class TimeConv:
     def add_frames(cls, tc: str, fps: float, nf: int) -> float:
         fps = round(fps, 2)
         return cls.tc2s(cls.add_framestc(tc, fps, nf), fps)
-    
+
     @classmethod
     def tc2pts(cls, tc: str, fps: float) -> float:
         return max(0, (cls.tc2s(tc, fps) - (1/3)/MPEGTS_FREQ)) * (1 if float(fps).is_integer() else 1.001)
+
+class SSIMPW:
+    use_gpu = True
+
+    @classmethod
+    def compare(cls, img1: Image.Image, img2: Image.Image) -> float:
+        return compare_ssim(img1, img2, GPU=cls.use_gpu)
 
 @lru_cache(maxsize=6)
 def get_matrix(matrix: str, to_rgba: bool, range: str) -> npt.NDArray[np.uint8]:

--- a/config.ini
+++ b/config.ini
@@ -3,6 +3,7 @@
 quality=100
 ; Specify the absolute or relative path to the external quantizer library or executable (pngquant or libimagequant)
 ; Path should uses slashes, not backslashes!
+; If you have PNGQUANT in %PATH%, the value here will be ignored.
 quantizer=G:/Software/pngquant/pngquant.exe
 
 [SUPer]

--- a/config.ini
+++ b/config.ini
@@ -4,3 +4,6 @@ quality=100
 ; Specify the absolute or relative path to the external quantizer library or executable (pngquant or libimagequant)
 ; Path should uses slashes, not backslashes!
 quantizer=G:/Software/pngquant/pngquant.exe
+
+[SUPer]
+use_gpu=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ opencv-python
 pyopencl
 SSIM-PIL
 timecode
+psutil ; sys_platform == 'win32'
 scenaristream @ git+https://github.com/cubicibo/ScenariStream.git
 piliq @ git+https://github.com/cubicibo/piliq.git
 # The following dependencies are optional:


### PR DESCRIPTION
Adds the long-awaited multithreading to SUPer. Both CLI and GUI supports it. Tested on Windows 10 and macOS 12 Monterey.
- CLI: `--threads N` (`-t N`), with 1 <= N <= 8.
- GUI: use drop-down menu.

For BDN XML with very long epochs, the highest thread count may lead to a memory surge and the OS using memory caches on the disk.

This MR also adds the possibility to disable GPU usage. In config.ini. Set `use_gpu`field to 0. (#21)