### PR TITLE
Adapt palette distribution to ratio of object sizes on normal cases redefinition

### DIFF
--- a/SUPer/render2.py
+++ b/SUPer/render2.py
@@ -558,10 +558,9 @@ class WindowsAnalyzer:
 
         #In this mode, we re-combine the two objects in a smaller areas than in the original box
         # and then pass that to the optimiser. Colors are efficiently distributed on the objects.
-        # In the future, this will be the default behaviour unless there's a NORMAL CASE to update
-        # to redefine an object in the middle.
         if has_two_objs and normal_case_refresh is False:
             compositions = [pgo for _, pgo in pgobs_items if not (pgo is None or not np.any(pgo.mask[i-pgo.f:k-pgo.f]))]
+            #todo: stack using slot dimensions?
             offset, dims = self.__class__._get_stack_direction(*list(map(lambda x: x.box, compositions)))
             imgs_chain = []
 
@@ -615,6 +614,7 @@ class WindowsAnalyzer:
             n_colors = 255
             bias = 0
             if has_two_objs:
+                assert normal_case_refresh
                 assert not any(filter(lambda x: x[0] < 0 or x[0] > self.box.dy or x[1] < 0 or x[1] > self.box.dx, node.slots)) and sum(map(lambda x: x is not None, node.slots)) == 2
                 f_slot_area = lambda slot: int(slot[0])*int(slot[1])
                 #ratio_area = (self.windows[0].area - self.windows[1].area)/sum(map(lambda wd: wd.area, self.windows))

--- a/supergui.py
+++ b/supergui.py
@@ -63,7 +63,7 @@ from SUPer.optim import Quantizer
 from SUPer.__metadata__ import __version__ as SUPVERS, __author__
 
 #### Functions, main at the end of the file
-def get_kwargs() -> dict[str, int]:
+def get_kwargs() -> dict[str, Any]:
     return {
         'quality_factor': int(compression_txt.value)/100,
         'refresh_rate': int(refresh_txt.value)/100,


### PR DESCRIPTION
Windows may be of vastly different sizes in an epoch. Furthermore, the buffer slots are not necessarily sized to the windows but to the largest occupied area in a frame. In normal case redefinition data stream sections, the palette is distributed between the two objects, and no ID shall be shared.
On occasions where the two objects differ vastly in surface area, the largest object should have more palette entries than the smaller one.

This MR adds logic to shift the boundary (within reasonable limits) whenever the object areas mismatch is significant.