### PR TITLE
Split large window to reduce DTS-PTS gap at epoch start.

### DIFF
--- a/SUPer/interface.py
+++ b/SUPer/interface.py
@@ -558,13 +558,11 @@ class EpochRenderer(mp.Process):
     def convert2(self, ectx: EpochContext, pcs_id: int = 0) -> tuple[Epoch, DisplaySet, int]:
         subgroup = ectx.events
         prefix = f"W{self.iid}: " if __class__.__threaded else ""
-        logger.info(prefix + f"EPOCH {subgroup[0].tc_in}->{subgroup[-1].tc_out}, {len(subgroup)}->{len(subgroup := remove_dupes(subgroup))} event(s):")
+        logger.info(prefix + f"EPOCH {subgroup[0].tc_in}->{subgroup[-1].tc_out}, {len(subgroup)}->{len(subgroup := remove_dupes(subgroup))} event(s), {len(ectx.windows)} window(s).")
 
         if logger.level <= 10:
             for w_id, wd in enumerate(ectx.windows):
                 logger.debug(f"Window {w_id}: X={wd.x+ectx.box.x}, Y={wd.y+ectx.box.y}, W={wd.dx}, H={wd.dy}")
-        else:
-            logger.info(prefix + f" => Screen layout: {len(ectx.windows)} window(s), processing...")
 
         wds_analyzer = WindowsAnalyzer(ectx.windows, ectx.events, ectx.box, self.bdn, pcs_id=pcs_id, **self.kwargs)
         new_epoch, final_ds, pcs_id = wds_analyzer.analyze()

--- a/config.ini
+++ b/config.ini
@@ -14,4 +14,8 @@ dither=95
 quantizer=G:/Software/pngquant/pngquant.exe
 
 [SUPer]
+; 1 - Use GPU optimised code. 0 - Use only CPU equivalent functions.
 use_gpu=1
+
+; Layout engine aggresiveness. 0: safe, 1: normal, 2: aggressive
+layout_mode=2


### PR DESCRIPTION
The Graphics Decoders pipelined rendering model is asymmetrical due to the different decoding and composition bandwidths. Some epoch layouts may have a total object decoding time that exceeds the initial wipe duration: the composition process gets delayed and only starts when the first object is decoded. If an object decoding time exceeds the initial wipe duration (the said object area occupies more than half of the screen), the equally large composition gets delayed. To minimize the idling time of the composition process, the largest object should be decoded while the composition process is busy clearing the graphics plane. The second smaller object may then be decoded while the first gets composited.