### PR TITLE
Use fractions for framerates.

### DIFF
--- a/SUPer/__init__.py
+++ b/SUPer/__init__.py
@@ -24,7 +24,7 @@ from .palette import Palette, PaletteEntry
 from .segments import PCS, WDS, ODS, PDS, ENDS, WindowDefinition, CObject, PGSegment, DisplaySet, Epoch
 from .filestreams import SUPFile, BDNXML
 from .optim import Preprocess, Optimise
-from .utils import BDVideo, TimeConv, LogFacility
+from .utils import BDVideo, TC, LogFacility
 from .pgraphics import PGraphics
 from .interface import BDNRender
 from .pgstream import is_compliant, test_diplayset, check_pts_dts_sanity, test_rx_bitrate

--- a/SUPer/optim.py
+++ b/SUPer/optim.py
@@ -369,7 +369,7 @@ class Optimise:
 
     @staticmethod
     def diff_cluts(cluts: npt.NDArray[np.uint8], /, *,
-                   matrix: str = 'bt709', s_range: str = 'limited') -> list[Palette]:
+                   matrix: str = 'bt709') -> list[Palette]:
         """
         This functions finds the chain of palette updates for consecutives cluts.
         :param cluts:  Color look-up tables of the sequence, stacked one after the other.
@@ -379,7 +379,7 @@ class Optimise:
         :return: N palette objects defining palette that can be converted to PDSes.
         """
         stacked_cluts = np.swapaxes(cluts, 1, 0).astype(np.int32)
-        matrix = get_matrix(matrix, False, s_range)
+        matrix = get_matrix(matrix, False)
 
         shape = stacked_cluts.shape
         stacked_cluts = np.round(np.matmul(stacked_cluts.reshape((-1, 4)), matrix.T))

--- a/SUPer/pgstream.py
+++ b/SUPer/pgstream.py
@@ -25,7 +25,7 @@ import numpy as np
 from .segments import PGSegment, PCS, WDS, PDS, ODS, ENDS, Epoch, DisplaySet
 from .pgraphics import PGDecoder, PGraphics, PGObjectBuffer
 from .palette import Palette
-from .utils import LogFacility, TimeConv as TC, Box
+from .utils import LogFacility, TC, Box
 
 logger = LogFacility.get_logger('SUPer')
 

--- a/SUPer/segments.py
+++ b/SUPer/segments.py
@@ -235,7 +235,7 @@ class CObject:
         STANDARD = 0x00
 
         @classmethod
-        def _missing_(cls, value: int) -> 'COFlags':
+        def _missing_(cls, value: int) -> 'CObject.COFlags':
             return cls.STANDARD
 
     def __init__(self, data: bytes, *, _cropped = False) -> None:
@@ -643,7 +643,6 @@ class PDS(PGSegment):
     A PaletteDefinitionSegment updates or defines the entries of a given palette.
     For a given DS, this class allows to visualize or set updates.
     """
-    _ids: list[int] = [] # Store the palette IDs used throughout a stream
 
     def __init__(self, data: bytes) -> None:
         super().__init__(data)

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -21,16 +21,15 @@ along with SUPer.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 import numpy as np
 
-from typing import Optional, Callable, TypeVar, Union
-import collections
+from typing import Optional, TypeVar, Union
 from logging.handlers import BufferingHandler
 from enum import Enum, IntEnum
-from numpy import (typing as npt)
+from numpy import typing as npt
+from fractions import Fraction
 from timecode import Timecode
 from dataclasses import dataclass
 from contextlib import nullcontext
 from functools import lru_cache
-from PIL import Image
 from SSIM_PIL import compare_ssim
 
 try:
@@ -208,18 +207,32 @@ class Box:
 
 #%%
 class BDVideo:
+    _LUT_PCS_FPS = {
+        23.976:0x10,
+        24:    0x20,
+        25:    0x30,
+        29.97: 0x40,
+        50:    0x60,
+        59.94: 0x70,
+        60:    0x80,
+    }
+
     class FPS(Enum):
-        HFR_60 = 60
-        NTSCi = 59.94
-        PALi  = 50
-        NTSCp = 29.97
-        PALp  = 25
-        FILM  = 24
-        FILM_NTSC = 23.976
+        HFR_60 = Fraction(60, 1)
+        NTSCi  = Fraction(60000, 1001)
+        PALi   = Fraction(50, 1)
+        NTSCp  = Fraction(30000, 1001)
+        PALp   = Fraction(25, 1)
+        FILM   = Fraction(24, 1)
+        FILM_NTSC = Fraction(24000, 1001)
 
         @classmethod
-        def from_pcsfps(self, pcsfps: int) -> 'BDVideo.FPS':
-            return next((k for k in BDVideo.LUT_PCS_FPS if BDVideo.LUT_PCS_FPS[k] == pcsfps), None)
+        def from_pcsfps(cls, pcsfps: int) -> 'BDVideo.FPS':
+            return cls(next(filter(lambda v: v[1] == pcsfps, BDVideo._LUT_PCS_FPS.items()))[0])
+
+        def to_pcsfps(self) -> 'BDVideo.PCSFPS':
+            rfps = round(float(self), 2)
+            return BDVideo.PCSFPS(next(filter(lambda v: rfps == round(v[0],2), BDVideo._LUT_PCS_FPS.items()))[1])
 
         @property
         def exact_value(self):
@@ -241,19 +254,25 @@ class BDVideo:
                 return cls(candidates[best_idx])
             raise ValueError("Framerate is not BD compliant.")
 
-        def __truediv__(self, other) -> float:
-            value = self.exact_value
-            return value/other
+        def __float__(self) -> float:
+            return float(self.value)
 
-        def __rtruediv__(self, other) -> float:
-            value = self.exact_value
-            return other/value
+        def __int__(self) -> int:
+            return int(self.value)
 
-        def __mul__(self, other) -> float:
-            value = self.exact_value
-            return other*value
+        def __round__(self, ndigits: int = 0):
+            return round(self.value, ndigits)
 
-        def __rmul__(self, other) -> float:
+        def __truediv__(self, other: Union[Fraction, float, int]) -> Union[Fraction, float]:
+            return self.value/other
+
+        def __rtruediv__(self, other: Union[Fraction, float, int]) -> Union[Fraction, float]:
+            return other/self.value
+
+        def __mul__(self, other: Union[Fraction, float, int]) -> Union[Fraction, float]:
+            return self.value*other
+
+        def __rmul__(self, other: Union[Fraction, float, int]) -> Union[Fraction, float]:
             return self.__mul__(other)
 
         def __float__(self) -> float:
@@ -262,19 +281,25 @@ class BDVideo:
         def __gt__(self, other):
             if isinstance(other, __class__):
                 return self.value > other.value
-            elif isinstance(other, (int, float)):
+            elif isinstance(other, (int, float, Fraction)):
                 return self.value > other
             return NotImplemented
 
         def __lt__(self, other):
             if isinstance(other, __class__):
                 return self.value < other.value
-            elif isinstance(other, (int, float)):
+            elif isinstance(other, (int, float, Fraction)):
                 return self.value < other
             return NotImplemented
 
+        def __ne__(self, other) -> bool:
+            test_eq = self.__eq__(other)
+            if test_eq == NotImplemented:
+                return test_eq
+            return not test_eq
+
         def __eq__(self, other) -> bool:
-            if isinstance(other, (float, int)):
+            if isinstance(other, (float, int, Fraction)):
                 try:
                     return __class__(other).value == self.value
                 except ValueError:
@@ -310,24 +335,9 @@ class BDVideo:
         NTSC_I      = 0x70
         HFR_60      = 0x80
 
-        @classmethod
-        def from_fps(cls, other: float):
-            return cls(BDVideo.LUT_PCS_FPS[np.round(other, 3)])
-
-    LUT_PCS_FPS = {
-        23.976:0x10,
-        24:    0x20,
-        25:    0x30,
-        29.97: 0x40,
-        50:    0x60,
-        59.94: 0x70,
-        60:    0x80,
-    }
-    LUT_FPS_PCSFPS = {v: k for k,v in LUT_PCS_FPS.items()}
-
     def __init__(self, fps: float, height: int, width: Optional[int] = None) -> None:
         self.fps = __class__.FPS(fps)
-        self.pcsfps = __class__.PCSFPS.from_fps(self.fps.value)
+        self.pcsfps = self.fps.to_pcsfps()
         if width is None:
             self.format = None
             for vf in __class__.VideoFormat:
@@ -339,12 +349,12 @@ class BDVideo:
             self.format = __class__.VideoFormat((width, height))
 
     @classmethod
-    def check_format_fps(cls, _format: 'BDVideo.VideoFormat', fps: float) -> bool:
+    def check_format_fps(cls, _format: 'BDVideo.VideoFormat', fps: Union[float, 'BDVideo.FPS', Fraction]) -> bool:
         valid = True
         fps = cls.FPS(fps)
         expected = [_fps for _fps in cls.FPS]
         if _format == cls.VideoFormat.HD720:
-            expected = [cls.FPS.NTSCi, cls.FPS.PALi, cls.FPS.FILM, cls.FPS.FILM_NTSC]
+            expected = [cls.FPS.FILM_NTSC, cls.FPS.FILM, cls.FPS.PALi, cls.FPS.NTSCi]
             valid &= fps in expected
         elif _format == cls.VideoFormat.SD576_43:
             expected = [cls.FPS.PALp, cls.FPS.PALi]
@@ -352,23 +362,41 @@ class BDVideo:
         elif _format == cls.VideoFormat.SD480_43:
             expected = [cls.FPS.NTSCp, cls.FPS.NTSCi]
             valid &= fps in expected
-        return valid, list(map(lambda x: x.value, expected))
+        return valid, list(map(lambda x: round((float if x.value.denominator == 1001 else int)(x), 3), expected))
 
 #%%
-class TimeConv:
+class TC(Timecode):
+    def __init__(self, fps, *args, **kwargs) -> None:
+        if not isinstance(fps, BDVideo.FPS):
+            fps = BDVideo.FPS(fps)
+        super().__init__(fps.value, *args, **kwargs)
+        self.fractional_fps = fps
+
     @classmethod
-    def s2tc(cls, s: float, fps: float, drop_frame: bool = False) -> Timecode:
+    def s2tc(cls, s: float, fps: float, drop_frame: bool = False) -> 'TC':
         #Add 1e-8 to avoid wrong rounding
         s = s/(1 if float(fps).is_integer() else 1.001)
-        r_tc = Timecode(round(fps, 2), start_seconds=s+1/fps+1e-8, force_non_drop_frame=True)
+        r_tc = cls(round(fps, 2), start_seconds=s+1/fps+1e-8, force_non_drop_frame=True)
         r_tc.drop_frame = drop_frame
         return r_tc
 
-    @classmethod
-    def tc2pts(cls, tc: Timecode) -> float:
-        secs = round(tc.float - Timecode(tc.framerate, '00:00:00:00', force_non_drop_frame=True).float, 6)
-        scale_ntsc = not float(tc.framerate).is_integer()
-        return max(0, (secs - (1/3)/MPEGTS_FREQ)) * (1 if not scale_ntsc else 1.001)
+    def to_pts(self) -> float:
+        tpts = ((self.frames - 1)/self.fractional_fps.value)*MPEGTS_FREQ
+        return (tpts.numerator//tpts.denominator)/MPEGTS_FREQ
+
+    def __add__(self, other: Union['TC', int]) -> 'TC':
+        # duplicate current one
+        tc = __class__(self.fractional_fps, frames=self.frames)
+        tc.drop_frame = self.drop_frame
+
+        if isinstance(other, __class__):
+            assert other.fractional_fps == self.fractional_fps
+            assert self.drop_frame == other.drop_frame == False
+            tc.add_frames(other.frames)
+        else:
+            assert isinstance(other, int)
+            tc.add_frames(other)
+        return tc
 
 class SSIMPW:
     use_gpu = True

--- a/SUPer/utils.py
+++ b/SUPer/utils.py
@@ -406,7 +406,7 @@ class SSIMPW:
         return compare_ssim(img1, img2, GPU=cls.use_gpu)
 
 @lru_cache(maxsize=6)
-def get_matrix(matrix: str, to_rgba: bool, range: str) -> npt.NDArray[np.uint8]:
+def get_matrix(matrix: str, to_rgba: bool) -> npt.NDArray[np.uint8]:
     """
     Getter of colorspace conversion matrix, BT ITU, limited or full
     :param matrix:       Conversion (BTxxx)
@@ -415,42 +415,38 @@ def get_matrix(matrix: str, to_rgba: bool, range: str) -> npt.NDArray[np.uint8]:
     """
 
     cc_matrix = {
-        'bt601': {'y2r_l': np.array([[1.164,       0,  1.596, 0],
+        'bt601': {'y2r':   np.array([[1.164,       0,  1.596, 0],
                                      [1.164,  -0.392, -0.813, 0],
                                      [1.164,   2.017,      0, 0],
                                      [    0,       0,      0, 1]]),
-                  'r2y_l': np.array([[ 0.257,  0.504,  0.098, 0],
+                  'r2y':   np.array([[ 0.257,  0.504,  0.098, 0],
                                      [-0.148, -0.291,  0.439, 0],
                                      [ 0.439, -0.368, -0.071, 0],
                                      [     0,      0,      0, 1]]),
         },
-        'bt709': {'y2r_l': np.array([[1.164,      0,   1.793, 0],
+        'bt709': {'y2r':   np.array([[1.164,      0,   1.793, 0],
                                      [1.164, -0.213,  -0.533, 0],
                                      [1.164,  2.112,       0, 0],
                                      [    0,      0,       0, 1]]),
-                  'r2y_l': np.array([[ 0.183,  0.614,  0.062, 0],
+                  'r2y':   np.array([[ 0.183,  0.614,  0.062, 0],
                                      [-0.101, -0.339,  0.439, 0],
                                      [ 0.439, -0.399, -0.040, 0],
                                      [     0,      0,      0, 1]]),
         },
-        'bt2020': {'y2r_l':np.array([[1.16439,      0,1.67867,0],
+        'bt2020': {'y2r':  np.array([[1.16439,      0,1.67867,0],
                                      [1.16439,-.18734,-.65042,0],
                                      [1.16439,2.14175,      0,0],
                                      [     0,      0,       0,1]]),
-                   'r2y_l':np.array([[0.22561,0.58228,0.05093,0],
+                   'r2y':  np.array([[0.22561,0.58228,0.05093,0],
                                      [-.12266,-.31656,0.43922,0],
                                      [0.43922,-.40389,-.03533,0],
                                      [      0,      0,      0,1]]),
         },
     }
-    if to_rgba:
-        mat = cc_matrix.get(matrix, {}).get(f"y2r_{range[0]}", None)
-    else:
-        mat = cc_matrix.get(matrix, {}).get(f"r2y_{range[0]}", None)
-
+    mat = cc_matrix.get(matrix, None)
     if mat is None:
         raise NotImplementedError("Unknown/Not implemented conversion standard.")
-    return mat
+    return mat["y2r" if to_rgba else "r2y"]
 
 class LogFacility:
     _logger = dict()

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -1,8 +1,9 @@
 import pytest
 
-from SUPer.utils import Box
-from SUPer.render2 import GroupingEngine
+from SUPer.utils import Box, TC, BDVideo, MPEGTS_FREQ, get_matrix
+from SUPer.render2 import PaddingEngine
 
+import warnings
 import numpy as np
 import random
 
@@ -16,126 +17,83 @@ def test_pad_box(container: Box):
         mx, my = random.randint(8, 64), random.randint(8, 64)
         py, px = random.randrange(0, container.dy, 1), random.randrange(0, container.dx, 1)
         input_box = Box(py, random.randint(1, container.dy-py), px, random.randint(1, container.dx-px))
-        ge = GroupingEngine(input_box, container, 2)
-        box = ge.pad_box(mx, my)
+        ge = PaddingEngine(input_box, container, 2)
+        box = PaddingEngine._pad_any_box(input_box, container, mx, my)
         if input_box.dx >= mx and input_box.dy >= my:
             assert input_box == box, f"{box} {input_box}"
         else:
             assert input_box.dx >= mx or box.dx == mx, f"{box} {input_box}"
             assert input_box.dy >= my or box.dy == my, f"{box} {input_box}"
 
-def test_pad_wds():
-    container = Box(0, 1080, 0, 1920)
-    input_box = Box(10, 100, 10, 100)
-
-    ge = GroupingEngine(input_box, container, 2)
-    box = ge.pad_box()
-    assert box == input_box
-
-    gs_orig = np.zeros((box.dy, box.dx), np.uint8)
-    gs_orig[ 0, 0] = 1
-    gs_orig[-1,-1] = 1
-    windows = ge.find_layout(gs_orig)
-    assert len(windows) == 2
-    np_mask = np.ones((box.dy, box.dx), np.bool_)
-    for wd in windows:
-        np_mask[wd.y:wd.y2, wd.x:wd.x2] = False
-        assert Box.union(wd, box).overlap_with(container) == 1.0
-        assert wd.dx == 8 and wd.dy == 8
-    assert not np.any(gs_orig[np_mask]), windows
-
-def test_merge_wds():
-    container = Box(0, 480, 0, 720)
-    box = Box(470, 10, 710, 10)
-
-    ge = GroupingEngine(box, container, 2)
-    assert ge.pad_box() == box
-
-    gs_orig = np.zeros((box.dy, box.dx), np.uint8)
-    gs_orig[0, 0] = 1
-    gs_orig[9, 9] = 1
-    windows = ge.find_layout(gs_orig)
-    assert len(windows) == 1, windows
-    np_mask = np.ones((box.dy, box.dx), np.bool_)
-
-    for wd in windows:
-        np_mask[wd.y:wd.y2, wd.x:wd.x2] = False
-        assert Box.union(wd, box).overlap_with(box) == 1.0
-        assert wd.dx >= 8 and wd.dy >= 8
-    assert not np.any(gs_orig[np_mask]), windows
-
-def test_merge_tick_overhead():
-    container = Box(0, 480, 0, 720)
-    box = Box(464, 16, 710, 10)
-
-    ge = GroupingEngine(box, container, 2)
-    assert ge.pad_box() == box
-
-    gs_orig = np.zeros((box.dy, box.dx), np.uint8)
-    gs_orig[0, 0] = 1
-    gs_orig[-1,0] = 1
-    windows = ge.find_layout(gs_orig)
-    assert len(windows) == 1, windows
-    np_mask = np.ones((box.dy, box.dx), np.bool_)
-    for wd in windows:
-        assert Box.union(wd, box).overlap_with(box) == 1.0
-        np_mask[wd.y:wd.y2, wd.x:wd.x2] = False
-    assert not np.any(gs_orig[np_mask]), (windows, np.argwhere(gs_orig[:, :] == 1))
-
-def test_split_tick_overhead():
-    container = Box(0, 480, 0, 720)
-    box = Box(464, 16, 0, 720)
-
-    ge = GroupingEngine(box, container, 2)
-    assert ge.pad_box() == box
-
-    gs_orig = np.zeros((box.dy, box.dx), np.uint8)
-    gs_orig[0, :] = 1
-    gs_orig[8, 0] = 1
-    windows = ge.find_layout(gs_orig)
-    assert len(windows) == 2, windows
-    np_mask = np.ones((box.dy, box.dx), np.bool_)
-    for wd in windows:
-        np_mask[wd.y:wd.y2, wd.x:wd.x2] = False
-        assert Box.union(wd, box).overlap_with(box) == 1.0
-        assert Box(wd.y+box.y, wd.dy, wd.x+box.x, wd.dx).overlap_with(container) == 1.0
-    assert not np.any(gs_orig[np_mask])
-
-def test_pad_marging_box():
-    container = Box(0, 480, 0, 720)
-    box = Box(464, 16, 0, 100)
-
-    ge = GroupingEngine(box, container, 2)
-    assert ge.pad_box() == box
-
-    gs_orig = np.zeros((box.dy, box.dx), np.uint8)
-    gs_orig[8, 0] = 1
-    gs_orig[10:13, :] = 1
-    windows = ge.find_layout(gs_orig)
-
-    np_mask = np.ones((box.dy, box.dx), np.bool_)
-    for wd in windows:
-        np_mask[wd.y:wd.y2, wd.x:wd.x2] = False
-        assert Box(wd.y+box.y, wd.dy, wd.x+box.x, wd.dx).overlap_with(container) == 1.0, windows
-    assert not np.any(gs_orig[np_mask])
-
-def test_single_window():
-    container = Box(0, 480, 0, 720)
-    box = Box(100, 100, 100, 100)
-    ge = GroupingEngine(box, container, 1)
-
-    gs_orig = np.zeros((box.dy, box.dx), np.uint8)
-    gs_orig[ 0, 0] = 1
-    gs_orig[-1,-1] = 1
-    assert len(ge.find_layout(gs_orig)) == 1
-
 def test_pad_centered_box():
     container = Box(0, 1080, 0, 1920)
     box = Box(538, 4, 959, 3)
 
-    ge = GroupingEngine(box, container, 1)
-    nbox = ge.pad_box()
+    ge = PaddingEngine(box, container, 1)
+    nbox = PaddingEngine._pad_any_box(box, container, 8, 8)
 
     #We expect perfect centering on Y axis, and accept off-by-one on X axis.
     assert abs(nbox.y-536) == 0 and abs(nbox.y2-544) == 0
     assert abs(nbox.x-956) <= 1 and abs(nbox.x2-964) <= 1
+
+####
+
+@pytest.mark.parametrize("fps", BDVideo.FPS)
+def test_tc_framegrid(fps: BDVideo.FPS):
+    #Known to produce correct result, yet totally different to SUPer implementation
+    def _tc2pts(tc: TC) -> float:
+        secs = round(tc.float - TC(tc.fractional_fps, '00:00:00:00', force_non_drop_frame=True).float, 6)
+        scale_ntsc = not float(tc.framerate).is_integer()
+        return max(0, (secs - (1/3)/MPEGTS_FREQ)) * (1 if not scale_ntsc else 1.001)
+
+    rtc = TC(fps, '00:00:00:00', force_non_drop_frame=True)
+    max_frames = TC(fps, f"23:59:59:{int(np.floor(fps))}", force_non_drop_frame=True).frames
+
+    while rtc.frames < max_frames:
+        assert round(MPEGTS_FREQ*_tc2pts(rtc)) == round(MPEGTS_FREQ*rtc.to_pts())
+        rtc += random.randint(1, 600)
+
+def test_get_matrix():
+    mbt709 = get_matrix('bt709', False)
+    mbt601 = get_matrix('bt601', False)
+    mbt2020 = get_matrix('bt2020', False)
+    assert not np.array_equal(mbt709, mbt601) and not np.array_equal(mbt601, mbt2020)
+    
+    try:
+        mbtgarb = get_matrix("12345", True)
+    except NotImplementedError:
+        ...
+
+@pytest.mark.parametrize("matrix", ['bt709', 'bt601', 'bt2020'])
+def test_get_matrix_inverse(matrix: str):
+    btd = get_matrix(matrix, False)
+    bti = get_matrix(matrix, True)
+    assert not np.array_equal(btd, bti)
+
+    assert np.all(np.abs(np.matmul(btd, bti) - np.eye(4)) < 12e-4)
+
+def test_pcs_fps():
+    vals = sorted([(fps, fps.to_pcsfps()) for fps in BDVideo.FPS], key=lambda x: x[1])
+
+    pcs_fps = 0x10
+    for k, fps in enumerate(sorted(BDVideo.FPS)):
+        assert vals[k] == (fps, pcs_fps)
+        pcs_fps += 0x10
+        if pcs_fps == 0x50: # 30 fps does not exist
+            pcs_fps += 0x10
+    
+
+def test_brule_capabilities():
+    from brule import Brule, LayoutEngine, HexTree
+
+    cap = Brule.get_capabilities()
+    if 'C' not in cap:
+        warnings.warn(f"RLE codec is unoptimized on your machine: {cap}.")
+
+    cap = LayoutEngine.get_capabilities()
+    if 'C' not in cap:
+        warnings.warn(f"The layout engine executes an unoptimized version on your machine: {cap}.")
+
+    cap = HexTree.get_capabilities()
+    if 'C' not in cap:
+        warnings.warn(f"The HexTree quantizer executes an unoptimized version on your machine: {cap}.")


### PR DESCRIPTION
Large refactor to remove the non-sensical (but correct) `TimeConv.tc2pts` implementation that had been deduced empirically with a more correct one.