### PR TITLE
Add periodic redraws on CLI

### DIFF
--- a/SUPer/interface.py
+++ b/SUPer/interface.py
@@ -33,7 +33,7 @@ from brule import LayoutEngine, Brule, HexTree, KDMeans
 
 from .utils import LogFacility, Box, SSIMPW
 from .pgraphics import PGDecoder
-from .filestreams import BDNXML, BDNXMLEvent, remove_dupes
+from .filestreams import BDNXML, BDNXMLEvent, remove_dupes, add_periodic_refreshes
 from .segments import Epoch, DisplaySet
 from .optim import Quantizer
 from .pgstream import is_compliant, check_pts_dts_sanity, test_rx_bitrate, EpochContext, debug_stats
@@ -605,6 +605,8 @@ class EpochWorker(mp.Process):
 
     def convert2(self, ectx: EpochContext, pcs_id: int = 0) -> tuple[Epoch, DisplaySet, int]:
         ectx.events = remove_dupes(ectx.events)
+        if (redraw_period := self.kwargs.get('redraw_period', 0)) >= 1:
+            ectx.events = add_periodic_refreshes(ectx.events, self.bdn.fps, redraw_period)
         prefix = f"W{self.iid}: " if __class__.__threaded else ""
         logger.info(prefix + f"Encoding epoch {ectx.events[0].tc_in}->{ectx.events[-1].tc_out} with {len(ectx.events)} event(s), {len(ectx.windows)} window(s).")
 

--- a/SUPer/render2.py
+++ b/SUPer/render2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Copyright (C) 2024 cibo
+Copyright (C) 2023-2025 cibo
 This file is part of SUPer <https://github.com/cubicibo/SUPer>.
 
 SUPer is free software: you can redistribute it and/or modify

--- a/supercli.py
+++ b/supercli.py
@@ -98,6 +98,7 @@ if __name__ == '__main__':
     parser.add_argument('--layout', help="Set window layout mode. [0: safe, 1: normal, 2: aggressive] (def: config.ini)", type=int, default=-1, required=False)
     parser.add_argument('--capabilities', help="Display Brule library capabilities and exit.", action=BruleCapAction)
 
+    parser.add_argument('--redraw-period', help="Add redraws every X >= 1.0 seconds [0: Disabled] - also known as 'acquisition point interval'. (def:  %(default)s)", type=float, default=0.0, required=False)
     parser.add_argument('--ssim-tol', help="Set a SSIM analysis offset (positive: higher sensitivity) [int, -100-100] (def:  %(default)s)", type=int, default=0, required=False)
 
     parser.add_argument('-v', '--version', action='version', version=f"(c) {__author__}, v{LIB_VERSION}")
@@ -113,6 +114,7 @@ if __name__ == '__main__':
     assert abs(args.ssim_tol) <= 100
     assert 0 <= args.compression <= 100
     assert 0 <= args.acqrate <= 100
+    assert 0 <= args.redraw_period
     if args.qmode not in range(0, 5):
         logger.warning("Unknown quantization mode, attempting to use pngquant/libimagequant.")
         args.qmode = 3
@@ -141,6 +143,10 @@ if __name__ == '__main__':
 
     if args.threads < 0 or args.threads > 10:
         exit_msg("Incorrect number of threads, aborting.")
+
+    if args.redraw_period < 1.0:
+        logger.warning("Meaningless redraw_period, setting to zero.")
+        args.redraw_period = 0
 
     if args.prefer_normal and not args.allow_normal:
         logger.warning("--prefer-normal requires --allow-normal, forcefully enabling this flag.")
@@ -208,6 +214,7 @@ if __name__ == '__main__':
         'log_to_file': args.log_to_file,
         'insert_acquisitions': args.extra_acq,
         'ssim_tol': args.ssim_tol/100,
+        'redraw_period': args.redraw_period,
         'threads': 'auto' if args.threads == 0 else args.threads,
     }
     ts_start = time.monotonic()


### PR DESCRIPTION
Add `--redraw-period` to insert periodic acquisition points, to redraw overlays that are on screen for a long time. Else, a seek past the initial draw would not display the said overlay.